### PR TITLE
Add config option for fail-on-impossible-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Usage:
     --enabledTests=ENABLEDTESTS                  Comma-separated list of the only tests to run, e.g. EntityCapsTest,SoftwareInfoIntegrationTest
     --enabledSpecifications=ENABLEDSPECIFICATIONS
                                                  Comma-separated list of the only specifications to run, e.g. XEP-0030,XEP-0199
+    --failOnImpossibleTest                       If set to 'true', fails the test run if any configured tests were impossible to execute. (default: 'false')
     --help                                       This help message
 ```
 


### PR DESCRIPTION
Test may be impossible to run, for example, because the server that's being tested does not support a particular feature.

It is not unreasonable for users to assume that, upon a successful test execution result, all tests have passed. In the case of 'impossible' tests, this isn't necessarily the case: some test might not have executed at all.

Especially in scenarios where users have configured the test run to enable a specific subset of the tests (through configuration such as enabledTests and enabledSpecifications) it may be desirable to hard fail when a test was impossible to execute. This enforces that a test run was strictly successful in all tests it was configured to execute.

fixes #4

Note that this is a documentation-only change for this particular runner.